### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,6 +1,8 @@
 version: 2.1
 
 description: >
-  This orb uses Snyk to find, fix and monitor known vulnerabilities in your app dependencies and docker image.
+  Use Snyk to find, fix and monitor known vulnerabilities in your app dependencies and docker image.
   To use this orb you need to have a registered account with snyk.io and and API token.
-  Repo: https://github.com/snyk/snyk-orb/
+display:
+  source_url: https://github.com/snyk/snyk-orb/
+  home_url: https://snyk.io/


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.