### PR TITLE
set SNYK_INTEGRATION_NAME to CIRCLECI_ORB

### DIFF
--- a/src/commands/scan.yml
+++ b/src/commands/scan.yml
@@ -61,6 +61,8 @@ steps:
   # install snyk
   - run:
       name: Download Snyk CLI
+      environment:
+        SNYK_INTEGRATION_NAME: CIRCLECI_ORB
       command: |
         if [[ ! -x "/usr/local/bin/snyk" ]]; then
           if [[ "<<parameters.os>>" == "alpine" && "<<parameters.install-alpine-dependencies>>" == "true" ]]; then
@@ -79,11 +81,15 @@ steps:
       steps:
         - run:
             name: "Run Snyk protect to apply patches from .snyk file"
+            environment:
+              SNYK_INTEGRATION_NAME: CIRCLECI_ORB
             command: |
               snyk protect <<parameters.additional-arguments>>
   # snyk test
   - run:
       name: "Run Snyk test to scan app for vulnerabilities"
+      environment:
+        SNYK_INTEGRATION_NAME: CIRCLECI_ORB
       command: >
         snyk test
         <<#parameters.docker-image-name>>--docker <<parameters.docker-image-name>><</parameters.docker-image-name>>
@@ -98,6 +104,8 @@ steps:
       steps:
         - run:
             name: "Run Snyk monitor for continuous monitoring on snyk.io"
+            environment:
+              SNYK_INTEGRATION_NAME: CIRCLECI_ORB
             command: >
               snyk monitor
               <<#parameters.docker-image-name>>--docker <<parameters.docker-image-name>><</parameters.docker-image-name>>


### PR DESCRIPTION
Update to set a `SNYK_INTEGRATION_NAME` env var equal to `CIRCLECI_ORB` for the execution of the Snyk CLI.
