### PR TITLE
feat: expose path param to iac job

### DIFF
--- a/src/jobs/scan-iac.yml
+++ b/src/jobs/scan-iac.yml
@@ -4,6 +4,13 @@ docker:
   - image: snyk/snyk-cli:npm
 resource_class: medium
 
+parameters:
+  path:
+    description: Path to a specific file or directory to test
+    type: string
+    default: ""
+
 steps:
   - checkout
-  - scan-iac
+  - scan-iac:
+      path: <<parameters.path>>


### PR DESCRIPTION
The job here is intended as a simple way of interfacing with the IaC test command, while the scan command can be used for the kitchen sink approach. This probably needs refining a bit in the future.

This PR exposes the path param at the job level, as without it the command is a little _too_ minimal. The rest of the config is left at the command level for granular control