### PR TITLE
Add more iac params

### DIFF
--- a/src/commands/scan-iac.yml
+++ b/src/commands/scan-iac.yml
@@ -1,7 +1,22 @@
-description: Scan your applications IaC files for issues
+description: Scan Terraform, Kubernetes, or CloudFormation files for issues
 parameters:
   path:
     description: Path to a specific file or directory to test
+    type: string
+    default: ""
+  severity-threshold:
+    description: Only report vulnerabilities of provided level or higher (low/medium/high/critical). Default is low.
+    type: enum
+    enum: ["low", "medium", "high", "critical"]
+    default: "low"
+  fail-on-issues:
+    description: This specifies if builds should be failed or continued based on issues found by Snyk.
+    type: boolean
+    default: true
+  organization:
+    description: >
+      Name of the Snyk organisation name, under which this project should be tested and monitored
+      If omitted the default organization will be used.
     type: string
     default: ""
   os:
@@ -37,3 +52,7 @@ steps:
         SNYK_INTEGRATION_VERSION: REPLACE_ORB_VERSION
       command: >
         snyk iac test <<#parameters.path>> <<parameters.path>><</parameters.path>>
+        <<#parameters.severity-threshold>>--severity-threshold=<<parameters.severity-threshold>><</parameters.severity-threshold>>
+        <<#parameters.organization>>--org=<<parameters.organization>><</parameters.organization>>
+        <<^parameters.fail-on-issues>> || true<</parameters.fail-on-issues>>
+

--- a/src/commands/scan-iac.yml
+++ b/src/commands/scan-iac.yml
@@ -51,7 +51,7 @@ steps:
         SNYK_INTEGRATION_NAME: CIRCLECI_ORB
         SNYK_INTEGRATION_VERSION: REPLACE_ORB_VERSION
       command: >
-        snyk iac test <<#parameters.path>> <<parameters.path>><</parameters.path>>
+        snyk iac test <<#parameters.path>><<parameters.path>><</parameters.path>>
         <<#parameters.severity-threshold>>--severity-threshold=<<parameters.severity-threshold>><</parameters.severity-threshold>>
         <<#parameters.organization>>--org=<<parameters.organization>><</parameters.organization>>
         <<^parameters.fail-on-issues>> || true<</parameters.fail-on-issues>>

--- a/src/jobs/scan-iac.yml
+++ b/src/jobs/scan-iac.yml
@@ -14,3 +14,7 @@ steps:
   - checkout
   - scan-iac:
       path: <<parameters.path>>
+      severity-threshold: <<parameters.severity-threshold>>
+      organization: <<parameters.organization>>
+      fail-on-issues: <<parameters.fail-on-issues>>
+      

--- a/src/jobs/scan-iac.yml
+++ b/src/jobs/scan-iac.yml
@@ -9,6 +9,21 @@ parameters:
     description: Path to a specific file or directory to test
     type: string
     default: ""
+  severity-threshold:
+    description: Only report vulnerabilities of provided level or higher (low/medium/high/critical). Default is low.
+    type: enum
+    enum: ["low", "medium", "high", "critical"]
+    default: "low"
+  organization:
+    description: >
+      Name of the Snyk organisation name, under which this project should be tested and monitored
+      If omitted the default organization will be used.
+    type: string
+    default: ""
+  fail-on-issues:
+    description: This specifies if builds should be failed or continued based on issues found by Snyk.
+    type: boolean
+    default: true
 
 steps:
   - checkout


### PR DESCRIPTION
Adding IAC params to the IAC command and job, mostly for controlling fail criteria and pointing to another org.