### PR TITLE
fix: Dont monitor by default for IaC

### DIFF
--- a/src/jobs/scan-iac.yml
+++ b/src/jobs/scan-iac.yml
@@ -17,3 +17,4 @@ steps:
   - scan:
       command: "iac test"
       additional-arguments: <<parameters.args>>
+      monitor-on-build: false


### PR DESCRIPTION
Snyk IaC test does not support monitor, so dont do it by default