### PR TITLE
fix: download sha256 file for verification

### DIFF
--- a/src/commands/scan.yml
+++ b/src/commands/scan.yml
@@ -74,7 +74,8 @@ steps:
           if [[ "<<parameters.os>>" == "alpine" && "<<parameters.install-alpine-dependencies>>" == "true" ]]; then
             apk add -q --no-progress --no-cache curl wget libstdc++ sudo
           fi
-          curl -s https://static.snyk.io/cli/latest/snyk-<<parameters.os>> -o snyk-<<parameters.os>>
+          curl -sO https://static.snyk.io/cli/latest/snyk-<<parameters.os>>
+          curl -sO https://static.snyk.io/cli/latest/snyk-<<parameters.os>>.sha256
           sha256sum -c snyk-<<parameters.os>>.sha256
           sudo mv snyk-<<parameters.os>> /usr/local/bin/snyk
           sudo chmod +x /usr/local/bin/snyk


### PR DESCRIPTION
In #54 we changed it to download the binary from our CDN, but previously it was using `xargs` to download both the binary and checksum in a single command.

The step after download needs the sha256 checksum.