### PR TITLE
Retry downloads with curl

### DIFF
--- a/src/commands/scan.yml
+++ b/src/commands/scan.yml
@@ -76,8 +76,8 @@ steps:
           fi
           LATEST_SNYK_CLI_VERSION=$(curl https://static.snyk.io/cli/latest/version)
           echo "Downloading Snyk CLI version ${LATEST_SNYK_CLI_VERSION}"
-          curl -sO https://static.snyk.io/cli/v${LATEST_SNYK_CLI_VERSION}/snyk-<<parameters.os>>
-          curl -sO https://static.snyk.io/cli/v${LATEST_SNYK_CLI_VERSION}/snyk-<<parameters.os>>.sha256
+          curl -sO --retry https://static.snyk.io/cli/v${LATEST_SNYK_CLI_VERSION}/snyk-<<parameters.os>>
+          curl -sO --retry https://static.snyk.io/cli/v${LATEST_SNYK_CLI_VERSION}/snyk-<<parameters.os>>.sha256
           sha256sum -c snyk-<<parameters.os>>.sha256
           sudo mv snyk-<<parameters.os>> /usr/local/bin/snyk
           sudo chmod +x /usr/local/bin/snyk


### PR DESCRIPTION
Occasionally downloads will fail for network errors. Leverage curl's internal retry to add more resiliency to the process.