### PR TITLE
Adding no_output_timeout param to snyk/scan #68

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ build:
         monitor-on-build: true                                    # create a snapshot of apps dependencies on snyk.io, for continoues monitoring (recommended!)
         project: ${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}-app  # use this to save the snapshot under specific names.
         organization: ${SNYK_CICD_ORGANIZATION}                   # save reports under a specific Snyk organization
+        no-output-timeout: 20m                                    # set timeout without output to 20 mins
 ```
 
 ## Orb Parameters
@@ -107,6 +108,7 @@ Full reference docs https://circleci.com/orbs/registry/orb/snyk/snyk
 | additional-arguments | Refer to the Snyk CLI help page for information on additional arguments | no | - | string |
 | os | The CLI OS version to download | no | linux | linux \| macos \| alpine |
 | install-alpine-dependencies | For the alpine CLI, should extenral dependencies be installed | no | true | boolean |
+| no-output-timeout | Elapsed time the command can run without output. The default is 10 minutes | no | 10m | string |
 
 ## Screenshots
 

--- a/src/commands/scan.yml
+++ b/src/commands/scan.yml
@@ -58,6 +58,10 @@ parameters:
     description: Install additional dependencies required by the alpine cli
     type: boolean
     default: true
+  no-output-timeout:
+    description: Elapsed time the command can run without output. The default is 10 minutes.
+    type: string
+    default: "10m"
 steps:
   # install snyk
   - run:
@@ -94,6 +98,8 @@ steps:
         <<#parameters.target-file>>--file=<<parameters.target-file>><</parameters.target-file>>
         <<parameters.additional-arguments>>
         <<^parameters.fail-on-issues>> || true<</parameters.fail-on-issues>>
+      no_output_timeout: >
+              <<parameters.no-output-timeout>>
   # snyk monitor
   - when:
       condition: <<parameters.monitor-on-build>>
@@ -110,3 +116,5 @@ steps:
               <<#parameters.organization>>--org=<<parameters.organization>><</parameters.organization>>
               <<#parameters.target-file>>--file=<<parameters.target-file>><</parameters.target-file>>
               <<parameters.additional-arguments>>
+            no_output_timeout: >
+              <<parameters.no-output-timeout>>


### PR DESCRIPTION
Adding **no_output_timeout** param to run execution.

Reference: https://circleci.com/docs/2.0/configuration-reference/#run

Default value always injected is 10m (10 Minutes) exactly the same from CircleCI defaults.