### PR TITLE
feat: add retry mechanism to fetch assets

### DIFF
--- a/src/commands/scan.yml
+++ b/src/commands/scan.yml
@@ -72,8 +72,8 @@ steps:
           fi
           LATEST_SNYK_CLI_VERSION=$(curl https://static.snyk.io/cli/latest/version)
           echo "Downloading Snyk CLI version ${LATEST_SNYK_CLI_VERSION}"
-          curl -sO https://static.snyk.io/cli/v${LATEST_SNYK_CLI_VERSION}/snyk-<<parameters.os>>
-          curl -sO https://static.snyk.io/cli/v${LATEST_SNYK_CLI_VERSION}/snyk-<<parameters.os>>.sha256
+          curl -sO --retry 6 https://static.snyk.io/cli/v${LATEST_SNYK_CLI_VERSION}/snyk-<<parameters.os>>
+          curl -sO --retry 6 https://static.snyk.io/cli/v${LATEST_SNYK_CLI_VERSION}/snyk-<<parameters.os>>.sha256
           sha256sum -c snyk-<<parameters.os>>.sha256
           sudo mv snyk-<<parameters.os>> /usr/local/bin/snyk
           sudo chmod +x /usr/local/bin/snyk


### PR DESCRIPTION
Downloads are retried up to 6 times with an exponential backoff, i.e. up to ~ 1 min

From https://linux.die.net/man/1/curl

> When curl is about to retry a transfer, it will first wait one second and then for all forthcoming retries it will double the waiting time until it reaches 10 minutes which then will be the delay between the rest of the retries.


closes #63 