### PR TITLE
fix: Remove line feed from no-output-timeout param in the latest orb version

### DIFF
--- a/src/commands/scan.yml
+++ b/src/commands/scan.yml
@@ -98,8 +98,7 @@ steps:
         <<#parameters.target-file>>--file=<<parameters.target-file>><</parameters.target-file>>
         <<parameters.additional-arguments>>
         <<^parameters.fail-on-issues>> || true<</parameters.fail-on-issues>>
-      no_output_timeout: >
-              <<parameters.no-output-timeout>>
+      no_output_timeout: "<<parameters.no-output-timeout>>"
   # snyk monitor
   - when:
       condition: <<parameters.monitor-on-build>>
@@ -116,5 +115,4 @@ steps:
               <<#parameters.organization>>--org=<<parameters.organization>><</parameters.organization>>
               <<#parameters.target-file>>--file=<<parameters.target-file>><</parameters.target-file>>
               <<parameters.additional-arguments>>
-            no_output_timeout: >
-              <<parameters.no-output-timeout>>
+            no_output_timeout: "<<parameters.no-output-timeout>>"


### PR DESCRIPTION
fix: Using the scan job in the latest version of the orb (v1.2.2 at the time of publishing) throws the following error:
* error decoding 'no_output_timeout': time: unknown unit "m\x0a" in duration "10m\x0a"
\x0A seems to be the escaped hexadecimal line feed, I believe this is happening due to the no_output_timeout param value being on a new line.
<img width="1546" alt="Screen Shot 2022-07-08 at 2 27 33 PM" src="https://user-images.githubusercontent.com/87317545/178064770-46afe73f-bcb1-4678-b559-4d1e9d9de874.png">