### PR TITLE
feat: cache snyk cli between versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea/

--- a/src/commands/scan.yml
+++ b/src/commands/scan.yml
@@ -73,14 +73,14 @@ steps:
       environment:
         SNYK_VERSION: <<parameters.cli-version>>
       command: |
-        if [[ -z "${SNYK_VERSION}" ]]
+        if [[ -z "${SNYK_VERSION}" ]]; then
           curl https://static.snyk.io/cli/latest/version > /tmp/.snyk-version
         else
-          echo ${SNYK_VERSION} >> /tmp/.snyk-version
+          echo "${SNYK_VERSION}" >> /tmp/.snyk-version
         fi
   - restore_cache:
       keys:
-        - v0-snyk-install-{{ arch }}-<<parameters.os>>-{{ checksum "/tmp/.snyk-version" }}
+        - v0-snyk-cli-install-{{ arch }}-<<parameters.os>>-{{ checksum "/tmp/.snyk-version" }}
   # install snyk
   - run:
       name: Download Snyk CLI
@@ -97,9 +97,10 @@ steps:
           curl -sO --retry 6 https://static.snyk.io/cli/v${LATEST_SNYK_CLI_VERSION}/snyk-<<parameters.os>>
           curl -sO --retry 6 https://static.snyk.io/cli/v${LATEST_SNYK_CLI_VERSION}/snyk-<<parameters.os>>.sha256
           sha256sum -c snyk-<<parameters.os>>.sha256
-          sudo mv snyk-<<parameters.os>> /usr/local/bin/snyk
-          sudo chmod +x /usr/local/bin/snyk
+          sudo mv snyk-<<parameters.os>> /tmp/snyk
+          sudo chmod +x /tmp/snyk
         fi
+        sudo ln -sf /tmp/snyk /usr/local/bin/snyk
         snyk config set disableSuggestions=true
         <<#parameters.token-variable>>snyk auth $<<parameters.token-variable>><</parameters.token-variable>>
   # snyk test
@@ -134,11 +135,7 @@ steps:
               <<#parameters.target-file>>--file=<<parameters.target-file>><</parameters.target-file>>
               <<parameters.additional-arguments>>
             no_output_timeout: "<<parameters.no-output-timeout>>"
-  - run:
-      when: always
-      name: Save Snyk CLI cache
-      steps:
-        - save-cache:
-            key: v0-snyk-install-{{ arch }}-<<parameters.os>>-{{ checksum "/tmp/.snyk-version" }}
-            paths:
-              - /usr/local/bin/snyk
+  - save_cache:
+      key: v0-snyk-cli-install-{{ arch }}-<<parameters.os>>-{{ checksum "/tmp/.snyk-version" }}
+      paths:
+        - /tmp/snyk

--- a/src/commands/scan.yml
+++ b/src/commands/scan.yml
@@ -45,6 +45,11 @@ parameters:
       If omitted a default-generated project name will be used.
     type: string
     default: ""
+  cli-version:
+    description: >
+      The version of the Snyk CLI you are using.
+    type: string
+    default: ""
   additional-arguments:
     description: Refer to the Snyk CLI help page for information on additional arguments.
     type: string
@@ -63,6 +68,19 @@ parameters:
     type: string
     default: "10m"
 steps:
+  - run:
+      name: Store Snyk CLI version as a temporary checksum file
+      environment:
+        SNYK_VERSION: <<parameters.cli-version>>
+      command: |
+        if [[ -z "${SNYK_VERSION}" ]]
+          curl https://static.snyk.io/cli/latest/version > /tmp/.snyk-version
+        else
+          echo ${SNYK_VERSION} >> /tmp/.snyk-version
+        fi
+  - restore_cache:
+      keys:
+        - v0-snyk-install-{{ arch }}-<<parameters.os>>-{{ checksum "/tmp/.snyk-version" }}
   # install snyk
   - run:
       name: Download Snyk CLI
@@ -116,3 +134,11 @@ steps:
               <<#parameters.target-file>>--file=<<parameters.target-file>><</parameters.target-file>>
               <<parameters.additional-arguments>>
             no_output_timeout: "<<parameters.no-output-timeout>>"
+  - run:
+      when: always
+      name: Save Snyk CLI cache
+      steps:
+        - save-cache:
+            key: v0-snyk-install-{{ arch }}-<<parameters.os>>-{{ checksum "/tmp/.snyk-version" }}
+            paths:
+              - /usr/local/bin/snyk

--- a/src/commands/scan.yml
+++ b/src/commands/scan.yml
@@ -71,12 +71,12 @@ steps:
   - run:
       name: Store Snyk CLI version as a temporary checksum file
       environment:
-        SNYK_VERSION: <<parameters.cli-version>>
+        SNYK_CLI_VERSION: <<parameters.cli-version>>
       command: |
-        if [[ -z "${SNYK_VERSION}" ]]; then
+        if [[ -z "${SNYK_CLI_VERSION}" ]]; then
           curl https://static.snyk.io/cli/latest/version > /tmp/.snyk-version
         else
-          echo "${SNYK_VERSION}" >> /tmp/.snyk-version
+          echo "${SNYK_CLI_VERSION}" >> /tmp/.snyk-version
         fi
   - restore_cache:
       keys:
@@ -88,14 +88,14 @@ steps:
         SNYK_INTEGRATION_NAME: CIRCLECI_ORB
         SNYK_INTEGRATION_VERSION: REPLACE_ORB_VERSION
       command: |
-        if [[ ! -x "/usr/local/bin/snyk" ]]; then
+        if [[ ! -x "/tmp/snyk" ]]; then
           if [[ "<<parameters.os>>" == "alpine" && "<<parameters.install-alpine-dependencies>>" == "true" ]]; then
             apk add -q --no-progress --no-cache curl wget libstdc++ sudo
           fi
-          LATEST_SNYK_CLI_VERSION=$(curl https://static.snyk.io/cli/latest/version)
-          echo "Downloading Snyk CLI version ${LATEST_SNYK_CLI_VERSION}"
-          curl -sO --retry 6 https://static.snyk.io/cli/v${LATEST_SNYK_CLI_VERSION}/snyk-<<parameters.os>>
-          curl -sO --retry 6 https://static.snyk.io/cli/v${LATEST_SNYK_CLI_VERSION}/snyk-<<parameters.os>>.sha256
+          SNYK_CLI_VERSION=$(cat "/tmp/.snyk-version")
+          echo "Downloading Snyk CLI version ${SNYK_CLI_VERSION}"
+          curl -sO --retry 6 https://static.snyk.io/cli/v${SNYK_CLI_VERSION}/snyk-<<parameters.os>>
+          curl -sO --retry 6 https://static.snyk.io/cli/v${SNYK_CLI_VERSION}/snyk-<<parameters.os>>.sha256
           sha256sum -c snyk-<<parameters.os>>.sha256
           sudo mv snyk-<<parameters.os>> /tmp/snyk
           sudo chmod +x /tmp/snyk


### PR DESCRIPTION
This change allows us to gather the version of Snyk we are targeting, attempt to restore from a CircleCI cache, and then install Snyk only if it is not present locally. This also allows you to set `cli-version` in a custom job so the snyk version can be fixed by a given project.