### PR TITLE
chore: Split scan command into reusable parts

### DIFF
--- a/src/commands/configure.yml
+++ b/src/commands/configure.yml
@@ -1,0 +1,18 @@
+description: Configure snyk CLI
+parameters:
+  token-variable:
+    description: >
+      Name of env var containing your Snyk API token. Pass this as a raw string such as CICD_SNYK_TOKEN.
+      Do not paste the actual token into your configuration.
+      If omitted it's assumed the CLI has already been setup with a valid token beforehand.
+    type: env_var_name
+    default: SNYK_TOKEN
+steps:
+  - run:
+      name: Configure Snyk CLI
+      environment:
+        SNYK_INTEGRATION_NAME: CIRCLECI_ORB
+        SNYK_INTEGRATION_VERSION: REPLACE_ORB_VERSION
+      command: |
+        snyk config set disableSuggestions=true
+        snyk auth $<<parameters.token-variable>>

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,0 +1,50 @@
+description: Install snyk CLI
+parameters:
+  cli-version:
+    description: >
+      The version of the Snyk CLI you are using.
+    type: string
+    default: ""
+  os:
+    description: The CLI OS version to download
+    type: enum
+    enum: ["linux", "macos", "alpine"]
+    default: "linux"
+  install-alpine-dependencies:
+    description: Install additional dependencies required by the alpine cli
+    type: boolean
+    default: true
+steps:
+  - run:
+      name: Store Snyk CLI version as a temporary checksum file
+      environment:
+        SNYK_CLI_VERSION: <<parameters.cli-version>>
+      command: |
+        if [[ -z "${SNYK_CLI_VERSION}" ]]; then
+          curl https://static.snyk.io/cli/latest/version > /tmp/.snyk-version
+        else
+          echo "${SNYK_CLI_VERSION}" >> /tmp/.snyk-version
+        fi
+  - restore_cache:
+      keys:
+        - v0-snyk-cli-install-{{ arch }}-<<parameters.os>>-{{ checksum "/tmp/.snyk-version" }}
+  - run:
+      name: Download Snyk CLI
+      command: |
+        if [[ ! -x "/tmp/snyk" ]]; then
+          if [[ "<<parameters.os>>" == "alpine" && "<<parameters.install-alpine-dependencies>>" == "true" ]]; then
+            apk add -q --no-progress --no-cache curl wget libstdc++ sudo
+          fi
+          SNYK_CLI_VERSION=$(cat "/tmp/.snyk-version")
+          echo "Downloading Snyk CLI version ${SNYK_CLI_VERSION}"
+          curl -sO --retry 6 https://static.snyk.io/cli/v${SNYK_CLI_VERSION}/snyk-<<parameters.os>>
+          curl -sO --retry 6 https://static.snyk.io/cli/v${SNYK_CLI_VERSION}/snyk-<<parameters.os>>.sha256
+          sha256sum -c snyk-<<parameters.os>>.sha256
+          sudo mv snyk-<<parameters.os>> /tmp/snyk
+          sudo chmod +x /tmp/snyk
+        fi
+        sudo ln -sf /tmp/snyk /usr/local/bin/snyk
+  - save_cache:
+      key: v0-snyk-cli-install-{{ arch }}-<<parameters.os>>-{{ checksum "/tmp/.snyk-version" }}
+      paths:
+        - /tmp/snyk

--- a/src/commands/scan.yml
+++ b/src/commands/scan.yml
@@ -68,41 +68,12 @@ parameters:
     type: string
     default: "10m"
 steps:
-  - run:
-      name: Store Snyk CLI version as a temporary checksum file
-      environment:
-        SNYK_CLI_VERSION: <<parameters.cli-version>>
-      command: |
-        if [[ -z "${SNYK_CLI_VERSION}" ]]; then
-          curl https://static.snyk.io/cli/latest/version > /tmp/.snyk-version
-        else
-          echo "${SNYK_CLI_VERSION}" >> /tmp/.snyk-version
-        fi
-  - restore_cache:
-      keys:
-        - v0-snyk-cli-install-{{ arch }}-<<parameters.os>>-{{ checksum "/tmp/.snyk-version" }}
-  # install snyk
-  - run:
-      name: Download Snyk CLI
-      environment:
-        SNYK_INTEGRATION_NAME: CIRCLECI_ORB
-        SNYK_INTEGRATION_VERSION: REPLACE_ORB_VERSION
-      command: |
-        if [[ ! -x "/tmp/snyk" ]]; then
-          if [[ "<<parameters.os>>" == "alpine" && "<<parameters.install-alpine-dependencies>>" == "true" ]]; then
-            apk add -q --no-progress --no-cache curl wget libstdc++ sudo
-          fi
-          SNYK_CLI_VERSION=$(cat "/tmp/.snyk-version")
-          echo "Downloading Snyk CLI version ${SNYK_CLI_VERSION}"
-          curl -sO --retry 6 https://static.snyk.io/cli/v${SNYK_CLI_VERSION}/snyk-<<parameters.os>>
-          curl -sO --retry 6 https://static.snyk.io/cli/v${SNYK_CLI_VERSION}/snyk-<<parameters.os>>.sha256
-          sha256sum -c snyk-<<parameters.os>>.sha256
-          sudo mv snyk-<<parameters.os>> /tmp/snyk
-          sudo chmod +x /tmp/snyk
-        fi
-        sudo ln -sf /tmp/snyk /usr/local/bin/snyk
-        snyk config set disableSuggestions=true
-        <<#parameters.token-variable>>snyk auth $<<parameters.token-variable>><</parameters.token-variable>>
+  - install:
+      cli-version: <<parameters.cli-version>>
+      os: <<parameters.os>>
+      install-alpine-dependencies: <<parameters.install-alpine-dependencies>>
+  - configure:
+      token-variable: <<parameters.token-variable>>
   # snyk test
   - run:
       name: "Run Snyk"
@@ -135,8 +106,3 @@ steps:
               <<#parameters.target-file>>--file=<<parameters.target-file>><</parameters.target-file>>
               <<parameters.additional-arguments>>
             no_output_timeout: "<<parameters.no-output-timeout>>"
-
-  - save_cache:
-      key: v0-snyk-cli-install-{{ arch }}-<<parameters.os>>-{{ checksum "/tmp/.snyk-version" }}
-      paths:
-        - /tmp/snyk

--- a/src/examples/multiple-scans.yml
+++ b/src/examples/multiple-scans.yml
@@ -1,0 +1,21 @@
+description: Run multiple scans in a single CI job
+usage:
+  version: "2.1"
+
+  orbs:
+    snyk: snyk/snyk@x.y.z
+
+  jobs:
+    scan:
+      docker:
+        - image: cimg/node:lts
+      steps:
+        - checkout
+        - snyk/install
+        - snyk/configure
+        - run:
+            name: Run SCA scan
+            command: snyk test
+        - run:
+            name: Run code scan
+            command snyk code test


### PR DESCRIPTION
Scan command does a lot apart from running scan:

 1. it installs snyk CLI tool and caches current version,
 2. it configures snyk, and finally
 3. it runs one snyk command.

And while this covers the simplest scenarios, it falls short when we
would like to call snyk more than once.

Changes in this pull request move the installation and configuration
steps into separate commands that developers can use on their own.

Do note that we left the scan command intact: it behaves exactly as it
behaved before our changes (it still performs all steps listed above).
We did this because we do not want to break existing CI pipelines.
