### PR TITLE
chore: create an install command and reuse it in the scan command

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,0 +1,65 @@
+description: Install Snyk CLI
+parameters:
+  token-variable:
+    description: >
+      Name of env var containing your Snyk API token. Pass this as a raw string such as CICD_SNYK_TOKEN.
+      Do not paste the actual token into your configuration.
+      If omitted it's assumed the CLI has already been setup with a valid token beforehand.
+    type: env_var_name
+    default: SNYK_TOKEN
+  cli-version:
+    description: >
+      The version of the Snyk CLI you are using.
+    type: string
+    default: ""
+  os:
+    description: The CLI OS version to download
+    type: enum
+    enum: ["linux", "macos", "alpine"]
+    default: "linux"
+  install-alpine-dependencies:
+    description: Install additional dependencies required by the alpine cli
+    type: boolean
+    default: true
+steps:
+  - run:
+      name: Install dependencies
+      command: |
+        if [[ "<<parameters.os>>" == "alpine" && "<<parameters.install-alpine-dependencies>>" == "true" ]]; then
+          apk add -q --no-progress --no-cache curl wget libstdc++ sudo
+        fi
+  - run:
+      name: Store Snyk CLI version as a temporary checksum file
+      environment:
+        SNYK_CLI_VERSION: <<parameters.cli-version>>
+      command: |
+        if [[ -z "${SNYK_CLI_VERSION}" ]]; then
+          curl https://static.snyk.io/cli/latest/version > /tmp/.snyk-version
+        else
+          echo "${SNYK_CLI_VERSION}" >> /tmp/.snyk-version
+        fi
+  - restore_cache:
+      keys:
+        - v0-snyk-cli-install-{{ arch }}-<<parameters.os>>-{{ checksum "/tmp/.snyk-version" }}
+  - run:
+      name: Download and configure Snyk CLI
+      environment:
+        SNYK_INTEGRATION_NAME: CIRCLECI_ORB
+        SNYK_INTEGRATION_VERSION: REPLACE_ORB_VERSION
+      command: |
+        if [[ ! -x "/tmp/snyk" ]]; then
+          SNYK_CLI_VERSION=$(cat "/tmp/.snyk-version")
+          echo "Downloading Snyk CLI version ${SNYK_CLI_VERSION}"
+          curl -sO --retry 6 https://static.snyk.io/cli/v${SNYK_CLI_VERSION}/snyk-<<parameters.os>>
+          curl -sO --retry 6 https://static.snyk.io/cli/v${SNYK_CLI_VERSION}/snyk-<<parameters.os>>.sha256
+          sha256sum -c snyk-<<parameters.os>>.sha256
+          sudo mv snyk-<<parameters.os>> /tmp/snyk
+          sudo chmod +x /tmp/snyk
+        fi
+        sudo ln -sf /tmp/snyk /usr/local/bin/snyk
+        snyk config set disableSuggestions=true
+        <<#parameters.token-variable>>snyk auth $<<parameters.token-variable>><</parameters.token-variable>>
+  - save_cache:
+      key: v0-snyk-cli-install-{{ arch }}-<<parameters.os>>-{{ checksum "/tmp/.snyk-version" }}
+      paths:
+        - /tmp/snyk

--- a/src/commands/scan.yml
+++ b/src/commands/scan.yml
@@ -68,44 +68,12 @@ parameters:
     type: string
     default: "10m"
 steps:
-  - run:
-      name: Install dependencies
-      command: |
-        if [[ "<<parameters.os>>" == "alpine" && "<<parameters.install-alpine-dependencies>>" == "true" ]]; then
-          apk add -q --no-progress --no-cache curl wget libstdc++ sudo
-        fi
-  - run:
-      name: Store Snyk CLI version as a temporary checksum file
-      environment:
-        SNYK_CLI_VERSION: <<parameters.cli-version>>
-      command: |
-        if [[ -z "${SNYK_CLI_VERSION}" ]]; then
-          curl https://static.snyk.io/cli/latest/version > /tmp/.snyk-version
-        else
-          echo "${SNYK_CLI_VERSION}" >> /tmp/.snyk-version
-        fi
-  - restore_cache:
-      keys:
-        - v0-snyk-cli-install-{{ arch }}-<<parameters.os>>-{{ checksum "/tmp/.snyk-version" }}
   # install snyk
-  - run:
-      name: Download Snyk CLI
-      environment:
-        SNYK_INTEGRATION_NAME: CIRCLECI_ORB
-        SNYK_INTEGRATION_VERSION: REPLACE_ORB_VERSION
-      command: |
-        if [[ ! -x "/tmp/snyk" ]]; then
-          SNYK_CLI_VERSION=$(cat "/tmp/.snyk-version")
-          echo "Downloading Snyk CLI version ${SNYK_CLI_VERSION}"
-          curl -sO --retry 6 https://static.snyk.io/cli/v${SNYK_CLI_VERSION}/snyk-<<parameters.os>>
-          curl -sO --retry 6 https://static.snyk.io/cli/v${SNYK_CLI_VERSION}/snyk-<<parameters.os>>.sha256
-          sha256sum -c snyk-<<parameters.os>>.sha256
-          sudo mv snyk-<<parameters.os>> /tmp/snyk
-          sudo chmod +x /tmp/snyk
-        fi
-        sudo ln -sf /tmp/snyk /usr/local/bin/snyk
-        snyk config set disableSuggestions=true
-        <<#parameters.token-variable>>snyk auth $<<parameters.token-variable>><</parameters.token-variable>>
+  - install:
+      cli-version: <<parameters.cli-version>>
+      os: <<parameters.os>>
+      install-alpine-dependencies: <<parameters.install-alpine-dependencies>>
+      token-variable: <<parameters.token-variable>>
   # snyk test
   - run:
       name: "Run Snyk"
@@ -138,8 +106,3 @@ steps:
               <<#parameters.target-file>>--file=<<parameters.target-file>><</parameters.target-file>>
               <<parameters.additional-arguments>>
             no_output_timeout: "<<parameters.no-output-timeout>>"
-
-  - save_cache:
-      key: v0-snyk-cli-install-{{ arch }}-<<parameters.os>>-{{ checksum "/tmp/.snyk-version" }}
-      paths:
-        - /tmp/snyk

--- a/src/examples/only-install.yml
+++ b/src/examples/only-install.yml
@@ -1,0 +1,22 @@
+description: >
+  Alternatively, you can use the Snyk orb to only install the Snyk CLI, and then run the Snyk CLI commands in your own steps.
+usage:
+  version: 2.1
+
+  orbs:
+    snyk: snyk/snyk@x.y.z
+
+  jobs:
+    build:
+      docker:
+        - image: cimg/node:lts
+      steps:
+        - checkout
+        - run: npm ci
+        - snyk/install
+        - run:
+            name: Which version of snyk is installed
+            command: snyk version
+        - run:
+            name: Run code scan
+            command: snyk code test


### PR DESCRIPTION
This PR aims at splitting the scan command into a reusable install command. It does not impact the scan command as I'm reusing the install command within it.

I decided to no split even further the install command like the [other PR](https://github.com/snyk/snyk-orb/pull/87) because a user could potentially forgot to configure the Snyk CLI.

Why this use case? As part of using the `snyk iac capture` command we want to be able to pipe the Terraform state and use our command with standard input. Furthermore, it makes the CircleCI orb behaving more like the Github Action.