### PR TITLE
Add retry-all-errors curl parameter

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -50,8 +50,8 @@ steps:
         if [[ ! -x "/tmp/snyk" ]]; then
           SNYK_CLI_VERSION=$(cat "/tmp/.snyk-version")
           echo "Downloading Snyk CLI version ${SNYK_CLI_VERSION}"
-          curl -sO --retry 6 https://static.snyk.io/cli/v${SNYK_CLI_VERSION}/snyk-<<parameters.os>>
-          curl -sO --retry 6 https://static.snyk.io/cli/v${SNYK_CLI_VERSION}/snyk-<<parameters.os>>.sha256
+          curl -sO --retry 6 --retry-all-errors https://static.snyk.io/cli/v${SNYK_CLI_VERSION}/snyk-<<parameters.os>>
+          curl -sO --retry 6 --retry-all-errors https://static.snyk.io/cli/v${SNYK_CLI_VERSION}/snyk-<<parameters.os>>.sha256
           sha256sum -c snyk-<<parameters.os>>.sha256
           sudo mv snyk-<<parameters.os>> /tmp/snyk
           sudo chmod +x /tmp/snyk


### PR DESCRIPTION
Lately we have seen `Exited with code exit status 56` quite often during the download Snyk CLI step. The error is transient and usually goes away with one manual rerun.

This PR adds an [extra option](https://everything.curl.dev/usingcurl/downloads/retry#retry-on-any-and-all-errors) to make curl retry even on network layer errors.

Related previous PR: https://github.com/snyk/snyk-orb/pull/63
