### PR TITLE
fix: checkout code, add semantic release dry run [HEAD-332]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,7 @@ workflows:
               ignore: master
       - deploy-to-dev:
           context:
+            - nodejs-lib-release
             - orb-publishing
           requires:
             - orb-tools/continue

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,7 @@ workflows:
               ignore: master
       - deploy-to-dev:
           context:
-            - nodejs-lib-release
+            - team-hammerhead-common-deploy-tokens
             - orb-publishing
           requires:
             - orb-tools/continue
@@ -159,7 +159,7 @@ workflows:
 
       - prod-release:
           context:
-            - nodejs-lib-release
+            - team-hammerhead-common-deploy-tokens
             - orb-publishing
           requires:
             - orb-tools/pack


### PR DESCRIPTION
Added the semantic release dry-run to dev and fixed usage of it (basically checking out source code before attaching the workspace), so that in the dev workflow the semantic release is started and tested, and we thus have more confidence that it will run through in prod, too. Added checkout to prod workflow before attaching workspace, too.