### PR TITLE
chore: add fallback for executors not supporting curl parameter `--retry-all-errors`

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -34,7 +34,7 @@ steps:
         SNYK_CLI_VERSION: <<parameters.cli-version>>
       command: |
         if [[ -z "${SNYK_CLI_VERSION}" ]]; then
-          curl --compressed --retry 6 --retry-all-errors https://static.snyk.io/cli/latest/version > /tmp/.snyk-version
+          curl --compressed --retry 6 --retry-all-errors https://static.snyk.io/cli/latest/version > /tmp/.snyk-version || curl --compressed --retry 6 https://static.snyk.io/cli/latest/version > /tmp/.snyk-version
         else
           echo "${SNYK_CLI_VERSION}" >> /tmp/.snyk-version
         fi        
@@ -51,8 +51,8 @@ steps:
         if [[ ! -x "/tmp/snyk" ]]; then
           SNYK_CLI_VERSION=$(cat "/tmp/.snyk-version")
           echo "Downloading Snyk CLI version ${SNYK_CLI_VERSION}"
-          curl -O --compressed --retry 6 --retry-all-errors https://static.snyk.io/cli/v${SNYK_CLI_VERSION}/snyk-<<parameters.os>>
-          curl -O --compressed --retry 6 --retry-all-errors https://static.snyk.io/cli/v${SNYK_CLI_VERSION}/snyk-<<parameters.os>>.sha256
+          curl -O --compressed --retry 6 --retry-all-errors https://static.snyk.io/cli/v${SNYK_CLI_VERSION}/snyk-<<parameters.os>> || curl -O --compressed --retry 6 https://static.snyk.io/cli/v${SNYK_CLI_VERSION}/snyk-<<parameters.os>>
+          curl -O --compressed --retry 6 --retry-all-errors https://static.snyk.io/cli/v${SNYK_CLI_VERSION}/snyk-<<parameters.os>>.sha256 || curl -O --compressed --retry 6 https://static.snyk.io/cli/v${SNYK_CLI_VERSION}/snyk-<<parameters.os>>
           sha256sum -c snyk-<<parameters.os>>.sha256
           sudo mv snyk-<<parameters.os>> /tmp/snyk
           sudo chmod +x /tmp/snyk


### PR DESCRIPTION
This retries all curl commands without the parameter if the call fails.