### PR TITLE
chore: secrets scanning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 setup: true
 orbs:
+  prodsec: snyk/prodsec-orb@1.0
   orb-tools: circleci/orb-tools@12.0.3
   node: circleci/node@5.1.0
 
@@ -134,6 +135,11 @@ jobs:
 workflows:
   btd:
     jobs:
+      - prodsec/secrets-scan:
+          name: Scan repository for secrets
+          context:
+            - snyk-bot-slack
+          channel: hammerhead-alerts
       - orb-tools/pack:
           orb_dir: packed
           orb_file_name: orb.yml

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,1 @@
+# add false positives here

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.17.0
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
Adds secrets scanning to the repository. Developers should use the provided pre-commit hooks to prevent the secrets from being pushed to the repository. See [https://pre-commit.com/](https://pre-commit.com/) for details.