### PR TITLE
feat(command-install): allow to install linux-arm64 cli version

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -20,7 +20,7 @@ parameters:
   os:
     description: The CLI OS version to download
     type: enum
-    enum: ["linux", "macos", "alpine"]
+    enum: ["linux", "macos", "alpine", "linux-arm64"]
     default: "linux"
   install-alpine-dependencies:
     description: Install additional dependencies required by the alpine cli


### PR DESCRIPTION
This PR allow to install the `linux-arm64` version of the CLI.

In the documentation [here](https://docs.snyk.io/snyk-cli/install-the-snyk-cli#install-with-standalone-executables) we can see that snyk is compatible with `arm64` like `aws graviton`. But the enum type in the orb didn't allow us to use it.

