### PR TITLE
feature: Allow passing additional options to `snyk monitor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,22 +95,23 @@ jobs:
 
 Full reference docs https://circleci.com/orbs/registry/orb/snyk/snyk
 
-| Parameter                   | Description                                                                                                                            | Required | Default    | Type                           |
-|-----------------------------|----------------------------------------------------------------------------------------------------------------------------------------|----------|------------|--------------------------------|
-| command                     | The CLI command (i.e. "test", "iac test") to execute                                                                                   | no       | test       | string                         |
-| token-variable              | Name of env var containing your Snyk API token                                                                                         | no       | SNYK_TOKEN | env_var_name                   |
-| severity-threshold          | Only report vulnerabilities of provided level or higher (low/medium/high/critical)                                                     | no       | low        | low \| med \| high \| critical |
-| fail-on-issues              | This specifies if builds should be failed or continued based on issues found by Snyk                                                   | no       | true       | boolean                        |
-| monitor-on-build            | Take a current application dependencies snapshot for continuous monitoring by Snyk, if test was succesful                              | no       | true       | boolean                        |
-| target-file                 | The path to the manifest file to be used by Snyk. Should be provided if non-standard                                                   | no       | -          | string                         |
-| docker-image-name           | The image name, if scanning a container image                                                                                          | no       | -          | string                         |
-| organization                | The Snyk Organization ID (see Organization-level Settings tab in the Snyk UI) under which this project should be tested and monitored. | no       | -          | string                         |
-| project                     | A custom name for the Snyk project to be created on snyk.io                                                                            | no       | -          | string                         |
-| additional-arguments        | Refer to the Snyk CLI help page for information on additional arguments                                                                | no       | -          | string                         |
-| os                          | The CLI OS version to download                                                                                                         | no       | linux      | linux \| macos \| alpine       |
-| install-alpine-dependencies | For the alpine CLI, should extenral dependencies be installed                                                                          | no       | true       | boolean                        |
-| no-output-timeout           | Elapsed time the command can run without output. The default is 10 minutes                                                             | no       | 10m        | string                         |
-| no-cache                    | Disable caching the Snyk CLI                                                                                                           | no       | false      | boolean                        |
+| Parameter                    | Description                                                                                                                            | Required | Default    | Type                           |
+|------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|----------|------------|--------------------------------|
+| command                      | The CLI command (i.e. "test", "iac test") to execute                                                                                   | no       | test       | string                         |
+| token-variable               | Name of env var containing your Snyk API token                                                                                         | no       | SNYK_TOKEN | env_var_name                   |
+| severity-threshold           | Only report vulnerabilities of provided level or higher (low/medium/high/critical)                                                     | no       | low        | low \| med \| high \| critical |
+| fail-on-issues               | This specifies if builds should be failed or continued based on issues found by Snyk                                                   | no       | true       | boolean                        |
+| monitor-on-build             | Take a current application dependencies snapshot for continuous monitoring by Snyk, if test was succesful                              | no       | true       | boolean                        |
+| target-file                  | The path to the manifest file to be used by Snyk. Should be provided if non-standard                                                   | no       | -          | string                         |
+| docker-image-name            | The image name, if scanning a container image                                                                                          | no       | -          | string                         |
+| organization                 | The Snyk Organization ID (see Organization-level Settings tab in the Snyk UI) under which this project should be tested and monitored. | no       | -          | string                         |
+| project                      | A custom name for the Snyk project to be created on snyk.io                                                                            | no       | -          | string                         |
+| additional-arguments         | Refer to the Snyk CLI help page for information on additional arguments. These are passed to all `snyk` commands.                      | no       | -          | string                         |
+| additional-monitor-arguments | Refer to the Snyk CLI help page for information on additional arguments. These are passed to `snyk monitor`.                           | no       | -          | string                         |
+| os                           | The CLI OS version to download                                                                                                         | no       | linux      | linux \| macos \| alpine       |
+| install-alpine-dependencies  | For the alpine CLI, should extenral dependencies be installed                                                                          | no       | true       | boolean                        |
+| no-output-timeout            | Elapsed time the command can run without output. The default is 10 minutes                                                             | no       | 10m        | string                         |
+| no-cache                     | Disable caching the Snyk CLI                                                                                                           | no       | false      | boolean                        |
 
 ## Screenshots
 

--- a/src/commands/scan.yml
+++ b/src/commands/scan.yml
@@ -54,6 +54,10 @@ parameters:
     description: Refer to the Snyk CLI help page for information on additional arguments.
     type: string
     default: ""
+  additional-monitor-arguments:
+    description: Refer to the Snyk CLI help page for information on additional arguments. These are passed only to the `snyk monitor` command.
+    type: string
+    default: ""
   no-cache:
     description: >
       Disable caching the Snyk CLI
@@ -118,4 +122,5 @@ steps:
               <<#parameters.organization>>--org=<<parameters.organization>><</parameters.organization>>
               <<#parameters.target-file>>--file=<<parameters.target-file>><</parameters.target-file>>
               <<parameters.additional-arguments>>
+              <<parameters.additional-monitor-arguments>>
             no_output_timeout: "<<parameters.no-output-timeout>>"


### PR DESCRIPTION
Some CLI arguments are specific to `snyk monitor`, and don't need to be passed to the `snyk test` command.
For example, `--project-tags` is available on `snyk monitor`, but not `snyk test`.