### PR TITLE
chore: Test snyk/scan commands with additional-arguments

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -13,26 +13,69 @@ commands:
   scan:
     description: test the scan functionality
     parameters:
+      fail-on-issues:
+        type: boolean
+        default: false
+      monitor-on-build:
+        type: boolean
+        default: false
       no-cache:
         type: boolean
         default: false
+      additional-arguments:
+        type: string
+        default: ''
+      additional-monitor-arguments:
+        type: string
+        default: ''
+
       test-only-param_fail-on-no-cache-used:
         type: boolean
         default: false
+      test-only-param_dry-run-commands:
+        type: boolean
+        default: false
+
     steps:
         - node/install
+
         - run:
             name: Setup test repository
             command: |
               git clone https://github.com/snyk-labs/nodejs-goof || echo "Repository already exists, no cloning needed."
               cd nodejs-goof
               npm install
+
         - snyk/scan:
-            fail-on-issues: false
-            monitor-on-build: false
             target-file: nodejs-goof/package.json
+
+            fail-on-issues: << parameters.fail-on-issues >>
+            monitor-on-build: << parameters.monitor-on-build >>
             no-cache: << parameters.no-cache >>
+            additional-arguments: << parameters.additional-arguments >>
+            additional-monitor-arguments: << parameters.additional-monitor-arguments >>
+
             test-only-param_fail-on-no-cache-used: << parameters.test-only-param_fail-on-no-cache-used >>
+            test-only-param_dry-run-commands: << parameters.test-only-param_dry-run-commands >>
+
+  validate-dry-run-commands:
+    description: validation hook to test the output of commands run under dry-run mode
+    parameters:
+      expected-commands:
+        type: string
+    steps:
+      - run:
+          name: Compare expected commands
+          command: >
+            if [[ "$(cat /tmp/dry-run-snyk-commands.txt)" != "$(printf "<< parameters.expected-commands >>")" ]]; then
+              echo "Expected Commands ========================================"
+              printf "<< parameters.expected-commands >>"
+
+              echo "Actual Commands =========================================="
+              cat /tmp/dry-run-snyk-commands.txt
+
+              false
+            fi
 
 jobs:
   scan-test:
@@ -70,6 +113,20 @@ jobs:
       - scan:
           no-cache: true
 
+  scan-test-monitor-additional-arguments:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - scan:
+          test-only-param_dry-run-commands: true
+          additional-arguments: "--print-deps"
+          additional-monitor-arguments: "--project-tags=component=pkg:github.com/snyk-labs/nodejs-goof"
+          monitor-on-build: true
+      - validate-dry-run-commands:
+          expected-commands: |
+            snyk test --severity-threshold=low --file=nodejs-goof/package.json --print-deps
+            snyk monitor --file=nodejs-goof/package.json --print-deps --project-tags=component=pkg:github.com/snyk-labs/nodejs-goof
+
 workflows:
   test-deploy:
     jobs:
@@ -94,6 +151,11 @@ workflows:
           filters: *filters
 
       - scan-test-ensure-cache-used:
+          context:
+            - hammerhead-snyk-orb-snyk-creds
+          filters: *filters
+
+      - scan-test-monitor-additional-arguments:
           context:
             - hammerhead-snyk-orb-snyk-creds
           filters: *filters

--- a/src/commands/scan.yml
+++ b/src/commands/scan.yml
@@ -82,6 +82,12 @@ parameters:
       It should not be used in production.
     type: boolean
     default: false
+  test-only-param_dry-run-commands:
+    description: >
+      This parameter is used to test arguments provided to the snyk commands.
+      It should not be used in production.
+    type: boolean
+    default: false
 steps:
   # install snyk
   - install:
@@ -98,6 +104,7 @@ steps:
         SNYK_INTEGRATION_NAME: CIRCLECI_ORB
         SNYK_INTEGRATION_VERSION: REPLACE_ORB_VERSION
       command: >
+        <<#parameters.test-only-param_dry-run-commands>>function capture() { echo "$@" | tee -a /tmp/dry-run-snyk-commands.txt; }; capture<</parameters.test-only-param_dry-run-commands>>
         snyk <<parameters.command>>
         <<#parameters.docker-image-name>>--docker <<parameters.docker-image-name>><</parameters.docker-image-name>>
         <<#parameters.severity-threshold>>--severity-threshold=<<parameters.severity-threshold>><</parameters.severity-threshold>>
@@ -116,6 +123,7 @@ steps:
               SNYK_INTEGRATION_NAME: CIRCLECI_ORB
               SNYK_INTEGRATION_VERSION: REPLACE_ORB_VERSION
             command: >
+              <<#parameters.test-only-param_dry-run-commands>>function capture() { echo "$@" | tee -a /tmp/dry-run-snyk-commands.txt; }; capture<</parameters.test-only-param_dry-run-commands>>
               snyk monitor
               <<#parameters.docker-image-name>>--docker <<parameters.docker-image-name>><</parameters.docker-image-name>>
               <<#parameters.project>>--project-name=<<parameters.project>><</parameters.project>>


### PR DESCRIPTION
The crux of this commit is this line.

```
test "$(cat /tmp/dry-run-snyk-commands.txt)" = "$(printf "<< parameters.expected-commands >>")"
```

A new parameter is created, `test-only-param_dry-run-commands`, which installs a shim to capture the command arguments passed to the `snyk` CLI.

Then, a validation step is run that compares the output of the commands the orb will run, vs the `expected-commands`.
An exact match string comparison is used, to set the result.