### PR TITLE
add macos-arm64

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -20,7 +20,7 @@ parameters:
   os:
     description: The CLI OS version to download
     type: enum
-    enum: ["linux", "macos", "alpine", "linux-arm64"]
+    enum: ["linux", "macos", "alpine", "linux-arm64", "macos-arm64"]
     default: "linux"
   install-alpine-dependencies:
     description: Install additional dependencies required by the alpine cli

--- a/src/commands/scan.yml
+++ b/src/commands/scan.yml
@@ -71,7 +71,7 @@ parameters:
   os:
     description: The CLI OS version to download
     type: enum
-    enum: ["linux", "macos", "alpine", "linux-arm64"]
+    enum: ["linux", "macos", "alpine", "linux-arm64", "macos-arm64"]
     default: "linux"
   install-alpine-dependencies:
     description: Install additional dependencies required by the alpine cli


### PR DESCRIPTION
x86_64 hosts now officially deprecated https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718
CLI releases have it pre-built already https://github.com/snyk/cli/releases